### PR TITLE
enforce integer division

### DIFF
--- a/pyDOE/doe_factorial.py
+++ b/pyDOE/doe_factorial.py
@@ -71,7 +71,7 @@ def fullfact(levels):
     level_repeat = 1
     range_repeat = np.prod(levels)
     for i in range(n):
-        range_repeat /= levels[i]
+        range_repeat //= levels[i]
         lvl = []
         for j in range(levels[i]):
             lvl += [j]*level_repeat


### PR DESCRIPTION
Force integer division in factorial design. Necessary for python 3.x. Fixes #8 