### PR TITLE
Fix float as integer warning in repeat_centers()

### DIFF
--- a/pyDOE/doe_box_behnken.py
+++ b/pyDOE/doe_box_behnken.py
@@ -70,7 +70,7 @@ def bbdesign(n, center=None):
     # - So, we created a factorial design with two factors
     # - Make two loops
     Index = 0
-    nb_lines = (n*(n-1)/2)*H_fact.shape[0]
+    nb_lines = int((0.5*n*(n-1))*H_fact.shape[0])
     H = repeat_center(n, nb_lines)
     
     for i in range(n - 1):


### PR DESCRIPTION
Removes warning in new versions of numpy which warn against using 'float' as 'int' as index.

`doe_repeat_center.py:43: VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future`

Addresses issue #11 