### PR TITLE
Change in the regex string of fracfact()

### DIFF
--- a/pyDOE/doe_factorial.py
+++ b/pyDOE/doe_factorial.py
@@ -189,7 +189,7 @@ def fracfact(gen):
        
     """
     # Recognize letters and combinations
-    A = [item for item in re.split('\-?\s?\+?', gen) if item]  # remove empty strings
+    A = [item for item in re.split('\-?\s\+?', gen) if item]  # remove empty strings
     C = [len(item) for item in A]
     
     # Indices of single letters (main factors)


### PR DESCRIPTION
The old regex string would consider the whitespace as an optional split point and would even split character like 'ab' in two separate letters. By changing it from \s? to \s we make the split only possible on '+' '-' and white spaces.